### PR TITLE
disabled generateMetaData to allow initial build

### DIFF
--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -7,22 +7,30 @@ import {
 import { notFound } from "next/navigation";
 import ProfilePageClient from "./ProfilePageClient";
 
-export async function generateMetaData({
+/* export async function generateMetaData({
   params,
 }: {
-  params: { username: string };
+  params: Promise<{ username: string }>;
 }) {
-  const user = await getProfileByUsername(params.username);
+  const { username } = await params;
+
+  const user = await getProfileByUsername(username);
   if (!user) return;
 
   return {
     title: `${user.name ?? user.username}`,
     description: user.bio || `Take a look at ${user.username}'s profile!`,
   };
-}
+} */
 
-async function ProfilePageServer({ params }: { params: { username: string } }) {
-  const user = await getProfileByUsername(params.username);
+export default async function ProfilePageServer({
+  params,
+}: {
+  params: Promise<{ username: string }>;
+}) {
+  const { username } = await params;
+
+  const user = await getProfileByUsername(username);
 
   if (!user) notFound();
 
@@ -41,5 +49,3 @@ async function ProfilePageServer({ params }: { params: { username: string } }) {
     />
   );
 }
-
-export default ProfilePageServer;


### PR DESCRIPTION
## PR Summary: Disable `generateMetaData` to Allow Initial Build

This pull request addresses a build-blocking issue by disabling the `generateMetaData` functionality, enabling the project to perform an initial build successfully.

### Key Changes

- **Disabled the `generateMetaData` feature/function:**  
  The `generateMetaData` code (component/function/module) was causing issues that prevented the initial build from completing. Temporarily disabling it allows the rest of the codebase to compile and run, facilitating further development and debugging.
- In `ProfilePageServer`, `params` is now treated as a `Promise` and the code will `await` it before accessing username

### Motivation

- **Unblocking the Build Process:**  
  The initial build was failing due to errors or issues related to `generateMetaData`. This change is a temporary workaround to get the project into a buildable state, so that development and testing can proceed.

### Next Steps

- **Investigate and Fix `generateMetaData`:**  
  The underlying problem with `generateMetaData` should be analyzed and resolved in a future update. Once addressed, the feature can be safely re-enabled without blocking the build.

---

**Note:**  
This is an interim solution. Please refer to the related source files and build logs for more details about the failure caused by `generateMetaData`.