### PR TITLE
textarea autofocus

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -236,6 +236,7 @@ function PostCard({
                       value={newComment}
                       onChange={(e) => setNewComment(e.target.value)}
                       className="min-h-[80px] resize-none"
+                      autoFocus
                     />
                     <div className="flex justify-end mt-2">
                       <Button


### PR DESCRIPTION
# PR Summary: Add `autofocus` to `<textarea>` Component

This pull request adds the `autofocus` attribute to the `<Textarea>` component rendered after clicking the comment button on a post. This ensures that the `textarea` is automatically focused when the component renders, allowing users to begin typing immediately without needing to click on the field.