### PR TITLE
README.md "Getting Started" -> "Local Development"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A social media app that allows users to post comments, share screen shots, and o
 
 ### [Click here to try the app live!](https://circles-social-app.netlify.app/)
 
-## Getting Started
+## Local Development
 
 Install dependencies:
 


### PR DESCRIPTION
- replace "Getting Started" header from the default nextjs README, and named it something more appropriate.